### PR TITLE
WIP: allow colors to be specified by hex code

### DIFF
--- a/app/src/main/kotlin/com/machinerychorus/lifeprogresswallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/kotlin/com/machinerychorus/lifeprogresswallpaper/WallpaperSettingsFragment.kt
@@ -2,6 +2,7 @@ package com.machinerychorus.lifeprogresswallpaper
 
 import android.graphics.Color
 import android.os.Bundle
+import android.widget.Toast
 import androidx.core.content.edit
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
@@ -14,6 +15,40 @@ import com.skydoves.colorpickerview.preference.ColorPickerPreferenceManager
 
 class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 
+	private fun setColor(prefKey: String, pref: ColorPreference?, newColor: String): Boolean {
+		val manager = ColorPickerPreferenceManager.getInstance(context)
+
+		var isvalid = false
+		var hexColor = 0
+		try {
+			hexColor = Color.parseColor(newColor)
+			isvalid = true
+		} catch (ignored: IllegalArgumentException) {
+		}
+
+		if (isvalid) {
+			manager.clearSavedColor(prefKey)
+			manager.clearSavedSelectorPosition(prefKey)
+			manager.clearSavedAlphaSliderPosition(prefKey)
+			manager.clearSavedBrightnessSlider(prefKey)
+			manager.setColor(prefKey, hexColor)
+			manager.restoreColorPickerData(pref?.getColorPickerView())
+			preferenceManager
+				.sharedPreferences?.edit {
+					putInt(prefKey, hexColor)
+				}
+			pref?.refresh()
+		} else {
+			val toast = Toast.makeText(
+				context,
+				"Invalid hex color",
+				Toast.LENGTH_SHORT
+			)
+			toast.show()
+		}
+		return isvalid
+	}
+
 	override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
 		setPreferencesFromResource(R.xml.preferences, rootKey)
 
@@ -22,8 +57,6 @@ class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 		val textPref = findPreference<EditTextPreference>(getString(R.string.goalsKey))
 		textPref?.setOnBindEditTextListener { editText -> editText.setHint(R.string.goalsHint) }
 
-		val manager = ColorPickerPreferenceManager.getInstance(context)
-
 		// listeners to keep hex and color selector in sync
 		val bgPref = findPreference<ColorPreference>(getString(R.string.bgColorKey))
 		val bgHexPref = findPreference<EditTextPreference>(getString(R.string.bgColorHexKey))
@@ -31,18 +64,7 @@ class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 			bgHexPref?.text = "#"+envelope.hexCode
 		})
 		bgHexPref?.setOnPreferenceChangeListener { _, newValue ->
-			manager.clearSavedColor(getString(R.string.bgColorKey))
-			manager.clearSavedSelectorPosition(getString(R.string.bgColorKey))
-			manager.clearSavedAlphaSliderPosition(getString(R.string.bgColorKey))
-			manager.clearSavedBrightnessSlider(getString(R.string.bgColorKey))
-			manager.setColor(getString(R.string.bgColorKey), Color.parseColor(newValue.toString()))
-			manager.restoreColorPickerData(bgPref?.getColorPickerView())
-			preferenceManager
-				.sharedPreferences?.edit {
-					putInt(getString(R.string.bgColorKey), Color.parseColor(newValue.toString()))
-				}
-			bgPref?.refresh()
-			true
+			setColor(getString(R.string.bgColorKey),bgPref,newValue.toString())
 		}
 
 		// listeners to keep hex and color selector in sync
@@ -52,18 +74,7 @@ class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 			fgHexPref?.text = "#"+envelope.hexCode
 		})
 		fgHexPref?.setOnPreferenceChangeListener { _, newValue ->
-			manager.clearSavedColor(getString(R.string.fgColorKey))
-			manager.clearSavedSelectorPosition(getString(R.string.fgColorKey))
-			manager.clearSavedAlphaSliderPosition(getString(R.string.fgColorKey))
-			manager.clearSavedBrightnessSlider(getString(R.string.fgColorKey))
-			manager.setColor(getString(R.string.fgColorKey), Color.parseColor(newValue.toString()))
-			manager.restoreColorPickerData(fgPref?.getColorPickerView())
-			preferenceManager
-				.sharedPreferences?.edit {
-					putInt(getString(R.string.fgColorKey), Color.parseColor(newValue.toString()))
-				}
-			fgPref?.refresh()
-			true
+			setColor(getString(R.string.fgColorKey),fgPref,newValue.toString())
 		}
 	}
 

--- a/app/src/main/kotlin/com/machinerychorus/lifeprogresswallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/kotlin/com/machinerychorus/lifeprogresswallpaper/WallpaperSettingsFragment.kt
@@ -1,10 +1,15 @@
 package com.machinerychorus.lifeprogresswallpaper
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.machinerychorus.lifeprogresswallpaper.customPrefs.DateDialogPreference
+import com.skydoves.colorpickerpreference.ColorPickerPreference
+import com.skydoves.colorpickerview.listeners.ColorEnvelopeListener
+import com.skydoves.colorpickerview.preference.ColorPickerPreferenceManager
+
 
 class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 
@@ -15,6 +20,42 @@ class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 		//we set it here to work around that
 		val textPref = findPreference<EditTextPreference>(getString(R.string.goalsKey))
 		textPref?.setOnBindEditTextListener { editText -> editText.setHint(R.string.goalsHint) }
+
+		val manager = ColorPickerPreferenceManager.getInstance(context)
+
+		// listeners to keep hex and color selector in sync
+		val bgPref = findPreference<ColorPickerPreference>(getString(R.string.bgColorKey))
+		val bgHexPref = findPreference<EditTextPreference>(getString(R.string.bgColorHexKey))
+		bgPref?.getColorPickerView()?.setColorListener(ColorEnvelopeListener { envelope, _ ->
+			bgHexPref?.text = "#"+envelope.hexCode
+		})
+		bgHexPref?.setOnPreferenceChangeListener { _, newValue ->
+			manager.clearSavedColor(getString(R.string.bgColorKey))
+			manager.clearSavedSelectorPosition(getString(R.string.bgColorKey))
+			manager.clearSavedAlphaSliderPosition(getString(R.string.bgColorKey))
+			manager.clearSavedBrightnessSlider(getString(R.string.bgColorKey))
+			manager.setColor(getString(R.string.bgColorKey), Color.parseColor(newValue.toString()))
+			manager.restoreColorPickerData(bgPref?.getColorPickerView())
+			// TODO: need way to redraw/refresh color_box
+			true
+		}
+
+		// listeners to keep hex and color selector in sync
+		val fgPref = findPreference<ColorPickerPreference>(getString(R.string.fgColorKey))
+		val fgHexPref = findPreference<EditTextPreference>(getString(R.string.fgColorHexKey))
+		fgPref?.getColorPickerView()?.setColorListener(ColorEnvelopeListener { envelope, _ ->
+			fgHexPref?.text = "#"+envelope.hexCode
+		})
+		fgHexPref?.setOnPreferenceChangeListener { _, newValue ->
+			manager.clearSavedColor(getString(R.string.fgColorKey))
+			manager.clearSavedSelectorPosition(getString(R.string.fgColorKey))
+			manager.clearSavedAlphaSliderPosition(getString(R.string.fgColorKey))
+			manager.clearSavedBrightnessSlider(getString(R.string.fgColorKey))
+			manager.setColor(getString(R.string.fgColorKey), Color.parseColor(newValue.toString()))
+			manager.restoreColorPickerData(fgPref?.getColorPickerView())
+			// TODO: need way to redraw/refresh color_box
+			true
+		}
 	}
 
 	override fun onDisplayPreferenceDialog(preference: Preference) {

--- a/app/src/main/kotlin/com/machinerychorus/lifeprogresswallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/kotlin/com/machinerychorus/lifeprogresswallpaper/WallpaperSettingsFragment.kt
@@ -2,11 +2,12 @@ package com.machinerychorus.lifeprogresswallpaper
 
 import android.graphics.Color
 import android.os.Bundle
+import androidx.core.content.edit
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.machinerychorus.lifeprogresswallpaper.customPrefs.DateDialogPreference
-import com.skydoves.colorpickerpreference.ColorPickerPreference
+import com.machinerychorus.lifeprogresswallpaper.customPrefs.ColorPreference
 import com.skydoves.colorpickerview.listeners.ColorEnvelopeListener
 import com.skydoves.colorpickerview.preference.ColorPickerPreferenceManager
 
@@ -24,7 +25,7 @@ class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 		val manager = ColorPickerPreferenceManager.getInstance(context)
 
 		// listeners to keep hex and color selector in sync
-		val bgPref = findPreference<ColorPickerPreference>(getString(R.string.bgColorKey))
+		val bgPref = findPreference<ColorPreference>(getString(R.string.bgColorKey))
 		val bgHexPref = findPreference<EditTextPreference>(getString(R.string.bgColorHexKey))
 		bgPref?.getColorPickerView()?.setColorListener(ColorEnvelopeListener { envelope, _ ->
 			bgHexPref?.text = "#"+envelope.hexCode
@@ -36,12 +37,16 @@ class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 			manager.clearSavedBrightnessSlider(getString(R.string.bgColorKey))
 			manager.setColor(getString(R.string.bgColorKey), Color.parseColor(newValue.toString()))
 			manager.restoreColorPickerData(bgPref?.getColorPickerView())
-			// TODO: need way to redraw/refresh color_box
+			preferenceManager
+				.sharedPreferences?.edit {
+					putInt(getString(R.string.bgColorKey), Color.parseColor(newValue.toString()))
+				}
+			bgPref?.refresh()
 			true
 		}
 
 		// listeners to keep hex and color selector in sync
-		val fgPref = findPreference<ColorPickerPreference>(getString(R.string.fgColorKey))
+		val fgPref = findPreference<ColorPreference>(getString(R.string.fgColorKey))
 		val fgHexPref = findPreference<EditTextPreference>(getString(R.string.fgColorHexKey))
 		fgPref?.getColorPickerView()?.setColorListener(ColorEnvelopeListener { envelope, _ ->
 			fgHexPref?.text = "#"+envelope.hexCode
@@ -53,7 +58,11 @@ class WallpaperSettingsFragment : PreferenceFragmentCompat() {
 			manager.clearSavedBrightnessSlider(getString(R.string.fgColorKey))
 			manager.setColor(getString(R.string.fgColorKey), Color.parseColor(newValue.toString()))
 			manager.restoreColorPickerData(fgPref?.getColorPickerView())
-			// TODO: need way to redraw/refresh color_box
+			preferenceManager
+				.sharedPreferences?.edit {
+					putInt(getString(R.string.fgColorKey), Color.parseColor(newValue.toString()))
+				}
+			fgPref?.refresh()
 			true
 		}
 	}

--- a/app/src/main/kotlin/com/machinerychorus/lifeprogresswallpaper/customPrefs/ColorPreference.kt
+++ b/app/src/main/kotlin/com/machinerychorus/lifeprogresswallpaper/customPrefs/ColorPreference.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2018 skydoves
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package com.machinerychorus.lifeprogresswallpaper.customPrefs
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.graphics.Color
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import android.util.AttributeSet
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.edit
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import com.machinerychorus.lifeprogresswallpaper.R
+import com.skydoves.colorpickerview.ColorEnvelope
+import com.skydoves.colorpickerview.ColorPickerDialog
+import com.skydoves.colorpickerview.ColorPickerView
+import com.skydoves.colorpickerview.listeners.ColorEnvelopeListener
+import com.skydoves.colorpickerview.listeners.ColorListener
+import com.skydoves.colorpickerview.listeners.ColorPickerViewListener
+
+/**
+ * ColorPreference is a preference for persisting a chosen color by users.
+ * We can show a [ColorPickerDialog] and customize the dialog and [ColorPickerView].
+ */
+class ColorPreference : Preference {
+
+	private lateinit var colorBox: View
+	private lateinit var preferenceDialog: AlertDialog
+	private lateinit var preferenceColorPickerView: ColorPickerView
+
+	var preferenceColorListener: ColorPickerViewListener? = null
+	var defaultColor: Int = Color.BLACK
+	var cornerRadius: Int = 0
+	var paletteDrawable: Drawable? = null
+	var selectorDrawable: Drawable? = null
+	var dialogTitle: String? = null
+	var positive: String? = null
+	var negative: String? = null
+	var attachAlphaSlideBar = true
+	var attachBrightnessSlideBar = true
+
+	constructor(context: Context) : super(context)
+
+	constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+		getAttrs(attrs)
+		onInit()
+	}
+
+	constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(
+		context,
+		attrs,
+		defStyleAttr
+	) {
+		getAttrs(attrs, defStyleAttr)
+		onInit()
+	}
+
+	private fun getAttrs(attrs: AttributeSet) {
+		val typedArray = context.obtainStyledAttributes(attrs, R.styleable.ColorPickerPreference)
+		try {
+			setTypeArray(typedArray)
+		} finally {
+			typedArray.recycle()
+		}
+	}
+
+	private fun getAttrs(attrs: AttributeSet, defStyle: Int) {
+		val typedArray =
+			context.obtainStyledAttributes(attrs, R.styleable.ColorPickerPreference, defStyle, 0)
+		try {
+			setTypeArray(typedArray)
+		} finally {
+			typedArray.recycle()
+		}
+	}
+
+	private fun setTypeArray(typedArray: TypedArray) {
+		defaultColor =
+			typedArray.getColor(R.styleable.ColorPickerPreference_default_color, defaultColor)
+		cornerRadius =
+			typedArray.getDimensionPixelSize(R.styleable.ColorPickerPreference_preference_colorBox_radius, cornerRadius)
+		paletteDrawable = typedArray.getDrawable(R.styleable.ColorPickerPreference_preference_palette)
+		selectorDrawable = typedArray.getDrawable(R.styleable.ColorPickerPreference_preference_selector)
+		dialogTitle = typedArray.getString(R.styleable.ColorPickerPreference_preference_dialog_title)
+		positive = typedArray.getString(R.styleable.ColorPickerPreference_preference_dialog_positive)
+		negative = typedArray.getString(R.styleable.ColorPickerPreference_preference_dialog_negative)
+		attachAlphaSlideBar =
+			typedArray.getBoolean(
+				R.styleable.ColorPickerPreference_preference_attachAlphaSlideBar,
+				attachAlphaSlideBar
+			)
+		attachBrightnessSlideBar =
+			typedArray.getBoolean(
+				R.styleable.ColorPickerPreference_preference_attachBrightnessSlideBar,
+				attachBrightnessSlideBar
+			)
+	}
+
+	fun onInit() {
+		widgetLayoutResource = R.layout.layout_colorpicker_preference
+		preferenceDialog = ColorPickerDialog.Builder(context).apply {
+			setTitle(dialogTitle)
+			setPositiveButton(
+				positive,
+				ColorEnvelopeListener { envelope, _ ->
+					if (colorBox.background is GradientDrawable) {
+						(colorBox.background as GradientDrawable).setColor(envelope.color)
+						notifyColorChanged(envelope)
+						preferenceManager
+							.sharedPreferences?.edit {
+								putInt(key, envelope.color)
+							}
+					}
+				}
+			)
+			setNegativeButton(negative) { dialogInterface, _ -> dialogInterface.dismiss() }
+			attachAlphaSlideBar(attachAlphaSlideBar)
+			attachBrightnessSlideBar(attachBrightnessSlideBar)
+			this@ColorPreference.preferenceColorPickerView = this.colorPickerView.apply {
+				paletteDrawable?.let { setPaletteDrawable(it) }
+				selectorDrawable?.let { setSelectorDrawable(it) }
+				preferenceName = key
+				setInitialColor(defaultColor)
+			}
+		}.create()
+	}
+
+	private fun notifyColorChanged(envelope: ColorEnvelope) {
+		preferenceColorListener?.let {
+			if (it is ColorListener) {
+				it.onColorSelected(envelope.color, true)
+			} else if (it is ColorEnvelopeListener) {
+				it.onColorSelected(envelope, true)
+			}
+		}
+	}
+
+	override fun onBindViewHolder(holder: PreferenceViewHolder) {
+		super.onBindViewHolder(holder)
+		colorBox = holder.findViewById(R.id.preference_colorBox)
+		colorBox.background = GradientDrawable().apply {
+			cornerRadius = this@ColorPreference.cornerRadius.toFloat()
+			setColor(
+				if (key == null) {
+					this@ColorPreference.defaultColor
+				} else {
+					preferenceManager.sharedPreferences!!.getInt(key, this@ColorPreference.defaultColor)
+				}
+			)
+		}
+	}
+
+	fun refresh() {
+		colorBox.background = GradientDrawable().apply {
+			cornerRadius = this@ColorPreference.cornerRadius.toFloat()
+			setColor(
+				if (key == null) {
+					this@ColorPreference.defaultColor
+				} else {
+					preferenceManager.sharedPreferences!!.getInt(key, this@ColorPreference.defaultColor)
+				}
+			)
+		}
+	}
+
+	override fun onClick() {
+		super.onClick()
+		preferenceDialog.show()
+	}
+
+	/** gets an [AlertDialog] that created by preferences. */
+	fun getPreferenceDialog(): AlertDialog = preferenceDialog
+
+	/** gets a [ColorPickerView] that created by preferences. */
+	fun getColorPickerView(): ColorPickerView = preferenceColorPickerView
+}

--- a/app/src/main/res/layout/layout_colorpicker_preference.xml
+++ b/app/src/main/res/layout/layout_colorpicker_preference.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content">
+
+  <LinearLayout
+    android:id="@+id/preference_colorBox"
+    android:layout_width="36dp"
+    android:layout_height="36dp"
+    android:layout_gravity="end|center_vertical"
+    android:orientation="vertical"
+    tools:background="#000000" />
+
+</FrameLayout>

--- a/app/src/main/res/values/attrs_colorpicker.xml
+++ b/app/src/main/res/values/attrs_colorpicker.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <declare-styleable name="ColorPickerPreference">
+    <attr name="default_color" format="color" />
+    <attr name="preference_colorBox" format="reference" />
+    <attr name="preference_colorBox_radius" format="dimension" />
+    <attr name="preference_palette" format="reference" />
+    <attr name="preference_selector" format="reference" />
+    <attr name="preference_dialog_title" format="string" />
+    <attr name="preference_dialog_positive" format="string" />
+    <attr name="preference_dialog_negative" format="string" />
+    <attr name="preference_attachAlphaSlideBar" format="boolean" />
+    <attr name="preference_attachBrightnessSlideBar" format="boolean" />
+  </declare-styleable>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,9 @@
 	<string name="title_activity_settings">Life Perspective</string>
 	<string name="birthdateKey">birthdate</string>
 	<string name="bgColorKey">bgColor</string>
+	<string name="bgColorHexKey">bgColorHex</string>
 	<string name="fgColorKey">fgColor</string>
+	<string name="fgColorHexKey">fgColorHex</string>
 	<string name="expectancyKey">expectancy</string>
 	<string name="progressFontSizeKey">progressFontSize</string>
 	<string name="decimalsKey">decimals</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -17,6 +17,11 @@
 		app:preference_attachAlphaSlideBar="false"
 		app:preference_dialog_negative="@string/cancel"
 		app:preference_dialog_positive="@string/confirm" />
+	<EditTextPreference
+		android:key="@string/bgColorHexKey"
+		android:defaultValue="@color/blackAsMySOUUUUUUUULLLL"
+		android:title="Background Hex"
+		app:useSimpleSummaryProvider="true" />
 	<com.skydoves.colorpickerpreference.ColorPickerPreference
 		android:key="@string/fgColorKey"
 		android:title="Foreground Color"
@@ -24,6 +29,11 @@
 		app:preference_attachAlphaSlideBar="false"
 		app:preference_dialog_negative="@string/cancel"
 		app:preference_dialog_positive="@string/confirm" />
+	<EditTextPreference
+		android:key="@string/fgColorHexKey"
+		app:defaultValue="@color/wholesomeTeal"
+		android:title="Foreground Hex"
+		app:useSimpleSummaryProvider="true" />
 	<com.machinerychorus.lifeprogresswallpaper.customPrefs.IntegerPreference
 		android:defaultValue="240"
 		android:key="@string/progressFontSizeKey"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -10,7 +10,7 @@
 		android:key="@string/expectancyKey"
 		android:title="Life Expectancy"
 		app:useSimpleSummaryProvider="true" />
-	<com.skydoves.colorpickerpreference.ColorPickerPreference
+	<com.machinerychorus.lifeprogresswallpaper.customPrefs.ColorPreference
 		android:key="@string/bgColorKey"
 		android:title="Background Color"
 		app:default_color="@color/blackAsMySOUUUUUUUULLLL"
@@ -22,7 +22,7 @@
 		android:defaultValue="@color/blackAsMySOUUUUUUUULLLL"
 		android:title="Background Hex"
 		app:useSimpleSummaryProvider="true" />
-	<com.skydoves.colorpickerpreference.ColorPickerPreference
+	<com.machinerychorus.lifeprogresswallpaper.customPrefs.ColorPreference
 		android:key="@string/fgColorKey"
 		android:title="Foreground Color"
 		app:default_color="@color/wholesomeTeal"


### PR DESCRIPTION
This my attempt to fix #15 

It's not quite there, as the color box in the settings screen does not update unless the dialog box is opened. But the dialog box does open with the value set by the hex edit box.

Is there a way to "refresh" or redraw the settings screen after a change? I'm tempted to load in the color picker lib (I don't actually know how to do this, but I'm up for attempting it), and add a "Redraw" method for the box.

Please review whenever you have a chance, thanks.